### PR TITLE
共通ビュー部品 CosmeticOverlayLabel を切り出し (refactor #22)

### DIFF
--- a/ReMake/View/CompareMakeupView.swift
+++ b/ReMake/View/CompareMakeupView.swift
@@ -57,168 +57,42 @@ struct CompareMakeupView: View {
                         if binding.wrappedValue == 0 {
                             // Face overlays
                             if let lip = record.selectedItems["lip"] {
-                                let values = lip.components(separatedBy: ", ")
-                                VStack(spacing: 2) {
-                                    Text("リップ")
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                    }
-                                }
-                                .offset(x: 0, y: 90)
+                                CosmeticOverlayLabel(title: "リップ", values: lip.components(separatedBy: ", "))
+                                    .offset(x: 0, y: 90)
                             }
                             if let highlight = record.selectedItems["highlight"] {
-                                let values = highlight.components(separatedBy: ", ")
-                                VStack(spacing: 2) {
-                                    Text("ハイライト")
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                    }
-                                }
-                                .offset(x: 40, y: -50)
+                                CosmeticOverlayLabel(title: "ハイライト", values: highlight.components(separatedBy: ", "))
+                                    .offset(x: 40, y: -50)
                             }
                             if let eyebrow = record.selectedItems["eyebrow"] {
-                                let values = eyebrow.components(separatedBy: ", ")
-                                VStack(spacing: 2) {
-                                    Text("アイブロウ")
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                    }
-                                }
-                                .offset(x: 70, y: -80)
+                                CosmeticOverlayLabel(title: "アイブロウ", values: eyebrow.components(separatedBy: ", "))
+                                    .offset(x: 70, y: -80)
                             }
                             if let base = record.selectedItems["base"] {
-                                let values = base.components(separatedBy: ", ")
-                                VStack(spacing: 2) {
-                                    Text("ベース")
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                    }
-                                }
-                                .offset(x: -70, y: 20)
+                                CosmeticOverlayLabel(title: "ベース", values: base.components(separatedBy: ", "))
+                                    .offset(x: -70, y: 20)
                             }
                             if let cheek = record.selectedItems["cheek"] {
-                                let values = cheek.components(separatedBy: ", ")
-                                VStack(spacing: 2) {
-                                    Text("チーク")
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                    }
-                                }
-                                .offset(x: 70, y: 20)
+                                CosmeticOverlayLabel(title: "チーク", values: cheek.components(separatedBy: ", "))
+                                    .offset(x: 70, y: 20)
                             }
                         } else if binding.wrappedValue == 1 {
                             // Eye overlays
                             if let eyeshadow = record.selectedItems["eyeshadow"] {
-                                let values = eyeshadow.components(separatedBy: ", ")
-                                VStack(spacing: 2) {
-                                    Text("アイシャドウ")
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                    }
-                                }
-                                .offset(x: 0, y: -70)
+                                CosmeticOverlayLabel(title: "アイシャドウ", values: eyeshadow.components(separatedBy: ", "))
+                                    .offset(x: 0, y: -70)
                             }
                             if let mascara = record.selectedItems["mascara"] {
-                                let values = mascara.components(separatedBy: ", ")
-                                VStack(spacing: 2) {
-                                    Text("マスカラ")
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                    }
-                                }
-                                .offset(x: -70, y: 0)
+                                CosmeticOverlayLabel(title: "マスカラ", values: mascara.components(separatedBy: ", "))
+                                    .offset(x: -70, y: 0)
                             }
                             if let colorlense = record.selectedItems["colorlense"] {
-                                let values = colorlense.components(separatedBy: ", ")
-                                VStack(spacing: 2) {
-                                    Text("カラコン")
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                    }
-                                }
-                                .offset(x: 0, y: 70)
+                                CosmeticOverlayLabel(title: "カラコン", values: colorlense.components(separatedBy: ", "))
+                                    .offset(x: 0, y: 70)
                             }
                             if let eyeliner = record.selectedItems["eyeliner"] {
-                                let values = eyeliner.components(separatedBy: ", ")
-                                VStack(spacing: 2) {
-                                    Text("アイライナー")
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                    }
-                                }
-                                .offset(x: 90, y: 0)
+                                CosmeticOverlayLabel(title: "アイライナー", values: eyeliner.components(separatedBy: ", "))
+                                    .offset(x: 90, y: 0)
                             }
                         }
                     }

--- a/ReMake/View/Components/CosmeticOverlayLabel.swift
+++ b/ReMake/View/Components/CosmeticOverlayLabel.swift
@@ -1,0 +1,46 @@
+//
+//  CosmeticOverlayLabel.swift
+//  ReMake
+//
+//  顔・目元イラストに重ねる「部位ラベル＋選択コスメ一覧」の共通ビュー部品。
+//  InputMakeupView / MakeupDetailView / CompareMakeupView の3画面で重複していた
+//  表示ブロックをここに切り出している。
+//
+
+import SwiftUI
+
+extension View {
+    /// 選択コスメ1件分のピル装飾（3画面共通）
+    func cosmeticPillStyle() -> some View {
+        self
+            .font(.caption)
+            .foregroundColor(.gray)
+            .padding(4)
+            .background(Color.white.opacity(0.6))
+            .cornerRadius(6)
+    }
+}
+
+/// 部位名のラベルと、その部位で選択されたコスメ一覧をまとめて表示する。
+/// 表示位置（`.position` / `.offset`）は呼び出し側で指定する。
+struct CosmeticOverlayLabel: View {
+    let title: String
+    let values: [String]
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(title)
+                .font(.caption)
+                .bold()
+                .foregroundColor(.black)
+            ForEach(values, id: \.self) { value in
+                Text(value)
+                    .cosmeticPillStyle()
+            }
+        }
+    }
+}
+
+#Preview {
+    CosmeticOverlayLabel(title: "リップ", values: ["キャンメイク 01", "ロムアンド 12"])
+}

--- a/ReMake/View/InputMakeupView.swift
+++ b/ReMake/View/InputMakeupView.swift
@@ -66,20 +66,8 @@ struct InputMakeupView: View {
                             // Example for .lip
                             VStack(spacing: 0) {
                                 if let values = viewModel.selectedItemLists[.lip] {
-                                    Text(viewModel.sectionTitle(for: .lip))
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
+                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .lip), values: values)
                                         .offset(y: -20)
-                                    ForEach(values, id: \.self) { value in
-                                        Text(value)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                            .offset(y: -20)
-                                    }
                                 }
                                 Button(action: {
                                     viewModel.setPicker(selection: .lip, title: "リップを選択", cosmetics: cosmetics)
@@ -94,20 +82,8 @@ struct InputMakeupView: View {
 
                             VStack(spacing: 0) {
                                 if let values = viewModel.selectedItemLists[.highlight] {
-                                    Text(viewModel.sectionTitle(for: .highlight))
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
+                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .highlight), values: values)
                                         .offset(y: -20)
-                                    ForEach(values, id: \.self) { value in
-                                        Text(value)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                            .offset(y: -20)
-                                    }
                                 }
                                 Button(action: {
                                     viewModel.setPicker(selection: .highlight, title: "ハイライト・シェーディングを選択", cosmetics: cosmetics)
@@ -122,20 +98,8 @@ struct InputMakeupView: View {
 
                             VStack(spacing: 0) {
                                 if let values = viewModel.selectedItemLists[.eyebrow] {
-                                    Text(viewModel.sectionTitle(for: .eyebrow))
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
+                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .eyebrow), values: values)
                                         .offset(y: -20)
-                                    ForEach(values, id: \.self) { value in
-                                        Text(value)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                            .offset(y: -20)
-                                    }
                                 }
                                 Button(action: {
                                     viewModel.setPicker(selection: .eyebrow, title: "アイブロウを選択", cosmetics: cosmetics)
@@ -194,20 +158,8 @@ struct InputMakeupView: View {
 
                             VStack(spacing: 0) {
                                 if let values = viewModel.selectedItemLists[.base] {
-                                    Text(viewModel.sectionTitle(for: .base))
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
+                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .base), values: values)
                                         .offset(y: -20)
-                                    ForEach(values, id: \.self) { value in
-                                        Text(value)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                            .offset(y: -20)
-                                    }
                                 }
                                 Button(action: {
                                     viewModel.setPicker(selection: .base, title: "ベースメイクを選択", cosmetics: cosmetics)
@@ -222,20 +174,8 @@ struct InputMakeupView: View {
 
                             VStack(spacing: 0) {
                                 if let values = viewModel.selectedItemLists[.cheek] {
-                                    Text(viewModel.sectionTitle(for: .cheek))
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
+                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .cheek), values: values)
                                         .offset(y: -20)
-                                    ForEach(values, id: \.self) { value in
-                                        Text(value)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                            .offset(y: -20)
-                                    }
                                 }
                                 Button(action: {
                                     viewModel.setPicker(selection: .cheek, title: "チークを選択", cosmetics: cosmetics)
@@ -251,20 +191,8 @@ struct InputMakeupView: View {
                             ZStack {
                                 VStack(spacing: 0) {
                                     if let values = viewModel.selectedItemLists[.eyeshadow] {
-                                        Text(viewModel.sectionTitle(for: .eyeshadow))
-                                            .font(.caption)
-                                            .bold()
-                                            .foregroundColor(.black)
+                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .eyeshadow), values: values)
                                             .offset(y: -30)
-                                        ForEach(values, id: \.self) { value in
-                                            Text(value)
-                                                .font(.caption)
-                                                .foregroundColor(.gray)
-                                                .padding(4)
-                                                .background(Color.white.opacity(0.6))
-                                                .cornerRadius(6)
-                                                .offset(y: -30)
-                                        }
                                     }
                                     Button(action: {
                                         viewModel.setPicker(selection: .eyeshadow, title: "アイシャドウを選択", cosmetics: cosmetics)
@@ -323,20 +251,8 @@ struct InputMakeupView: View {
 
                                 VStack(spacing: 0) {
                                     if let values = viewModel.selectedItemLists[.mascara] {
-                                        Text(viewModel.sectionTitle(for: .mascara))
-                                            .font(.caption)
-                                            .bold()
-                                            .foregroundColor(.black)
+                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .mascara), values: values)
                                             .offset(y: -30)
-                                        ForEach(values, id: \.self) { value in
-                                            Text(value)
-                                                .font(.caption)
-                                                .foregroundColor(.gray)
-                                                .padding(4)
-                                                .background(Color.white.opacity(0.6))
-                                                .cornerRadius(6)
-                                                .offset(y: -30)
-                                        }
                                     }
                                     Button(action: {
                                         viewModel.setPicker(selection: .mascara, title: "マスカラを選択", cosmetics: cosmetics)
@@ -351,20 +267,8 @@ struct InputMakeupView: View {
 
                                 VStack(spacing: 0) {
                                     if let values = viewModel.selectedItemLists[.colorlense] {
-                                        Text(viewModel.sectionTitle(for: .colorlense))
-                                            .font(.caption)
-                                            .bold()
-                                            .foregroundColor(.black)
+                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .colorlense), values: values)
                                             .offset(y: -30)
-                                        ForEach(values, id: \.self) { value in
-                                            Text(value)
-                                                .font(.caption)
-                                                .foregroundColor(.gray)
-                                                .padding(4)
-                                                .background(Color.white.opacity(0.6))
-                                                .cornerRadius(6)
-                                                .offset(y: -30)
-                                        }
                                     }
                                     Button(action: {
                                         viewModel.setPicker(selection: .colorlense, title: "カラコンを選択", cosmetics: cosmetics)
@@ -379,20 +283,8 @@ struct InputMakeupView: View {
 
                                 VStack(spacing: 0) {
                                     if let values = viewModel.selectedItemLists[.eyeliner] {
-                                        Text(viewModel.sectionTitle(for: .eyeliner))
-                                            .font(.caption)
-                                            .bold()
-                                            .foregroundColor(.black)
+                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .eyeliner), values: values)
                                             .offset(y: -30)
-                                        ForEach(values, id: \.self) { value in
-                                            Text(value)
-                                                .font(.caption)
-                                                .foregroundColor(.gray)
-                                                .padding(4)
-                                                .background(Color.white.opacity(0.6))
-                                                .cornerRadius(6)
-                                                .offset(y: -30)
-                                        }
                                     }
                                     Button(action: {
                                         viewModel.setPicker(selection: .eyeliner, title: "アイラインを選択", cosmetics: cosmetics)

--- a/ReMake/View/MakeupDetailView.swift
+++ b/ReMake/View/MakeupDetailView.swift
@@ -39,110 +39,40 @@ struct  MakeupDetailView: View {
                         VStack(spacing: 0) {
                             let values = viewModel.values(for: .lip)
                             if !values.isEmpty {
-                                VStack(spacing: 2) {
-                                    Text(viewModel.title(for: .lip))
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                        .offset(y: -20)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                            .offset(y: -20)
-                                    }
-                                }
+                                CosmeticOverlayLabel(title: viewModel.title(for: .lip), values: values)
+                                    .offset(y: -20)
                             }
                         }
                         .position(x: 218, y: 285)
                         VStack(spacing: 0) {
                             let values = viewModel.values(for: .highlight)
                             if !values.isEmpty {
-                                VStack(spacing: 2) {
-                                    Text(viewModel.title(for: .highlight))
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                        .offset(y: -20)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                            .offset(y: -20)
-                                    }
-                                }
+                                CosmeticOverlayLabel(title: viewModel.title(for: .highlight), values: values)
+                                    .offset(y: -20)
                             }
                         }
                         .position(x: 200, y: 208)
                         VStack(spacing: 0) {
                             let values = viewModel.values(for: .eyebrow)
                             if !values.isEmpty {
-                                VStack(spacing: 2) {
-                                    Text(viewModel.title(for: .eyebrow))
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                        .offset(y: -20)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                            .offset(y: -20)
-                                    }
-                                }
+                                CosmeticOverlayLabel(title: viewModel.title(for: .eyebrow), values: values)
+                                    .offset(y: -20)
                             }
                         }
                         .position(x: 278, y: 152)
                         VStack(spacing: 0) {
                             let values = viewModel.values(for: .base)
                             if !values.isEmpty {
-                                VStack(spacing: 2) {
-                                    Text(viewModel.title(for: .base))
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                        .offset(y: -20)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                            .offset(y: -20)
-                                    }
-                                }
+                                CosmeticOverlayLabel(title: viewModel.title(for: .base), values: values)
+                                    .offset(y: -20)
                             }
                         }
                         .position(x: 135, y: 247)
                         VStack(spacing: 0) {
                             let values = viewModel.values(for: .cheek)
                             if !values.isEmpty {
-                                VStack(spacing: 2) {
-                                    Text(viewModel.title(for: .cheek))
-                                        .font(.caption)
-                                        .bold()
-                                        .foregroundColor(.black)
-                                        .offset(y: -20)
-                                    ForEach(values, id: \.self) { val in
-                                        Text(val)
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                            .padding(4)
-                                            .background(Color.white.opacity(0.6))
-                                            .cornerRadius(6)
-                                            .offset(y: -20)
-                                    }
-                                }
+                                CosmeticOverlayLabel(title: viewModel.title(for: .cheek), values: values)
+                                    .offset(y: -20)
                             }
                         }
                         .position(x: 270, y: 230)
@@ -150,89 +80,33 @@ struct  MakeupDetailView: View {
                         ZStack {
                             VStack(spacing: 0) {
                                 let values = viewModel.values(for: .eyeshadow)
-                            if !values.isEmpty {
-                                    VStack(spacing: 2) {
-                                        Text(viewModel.title(for: .eyeshadow))
-                                            .font(.caption)
-                                            .bold()
-                                            .foregroundColor(.black)
-                                            .offset(y: -30)
-                                        ForEach(values, id: \.self) { val in
-                                            Text(val)
-                                                .font(.caption)
-                                                .foregroundColor(.gray)
-                                                .padding(4)
-                                                .background(Color.white.opacity(0.6))
-                                                .cornerRadius(6)
-                                                .offset(y: -30)
-                                        }
-                                    }
+                                if !values.isEmpty {
+                                    CosmeticOverlayLabel(title: viewModel.title(for: .eyeshadow), values: values)
+                                        .offset(y: -30)
                                 }
                             }
                             .position(x: 150, y: 90)
                             VStack(spacing: 0) {
                                 let values = viewModel.values(for: .mascara)
-                            if !values.isEmpty {
-                                    VStack(spacing: 2) {
-                                        Text(viewModel.title(for: .mascara))
-                                            .font(.caption)
-                                            .bold()
-                                            .foregroundColor(.black)
-                                            .offset(y: -30)
-                                        ForEach(values, id: \.self) { val in
-                                            Text(val)
-                                                .font(.caption)
-                                                .foregroundColor(.gray)
-                                                .padding(4)
-                                                .background(Color.white.opacity(0.6))
-                                                .cornerRadius(6)
-                                                .offset(y: -30)
-                                        }
-                                    }
+                                if !values.isEmpty {
+                                    CosmeticOverlayLabel(title: viewModel.title(for: .mascara), values: values)
+                                        .offset(y: -30)
                                 }
                             }
                             .position(x: 270, y: 100)
                             VStack(spacing: 0) {
                                 let values = viewModel.values(for: .colorlense)
-                            if !values.isEmpty {
-                                    VStack(spacing: 2) {
-                                        Text(viewModel.title(for: .colorlense))
-                                            .font(.caption)
-                                            .bold()
-                                            .foregroundColor(.black)
-                                            .offset(y: -30)
-                                        ForEach(values, id: \.self) { val in
-                                            Text(val)
-                                                .font(.caption)
-                                                .foregroundColor(.gray)
-                                                .padding(4)
-                                                .background(Color.white.opacity(0.6))
-                                                .cornerRadius(6)
-                                                .offset(y: -30)
-                                        }
-                                    }
+                                if !values.isEmpty {
+                                    CosmeticOverlayLabel(title: viewModel.title(for: .colorlense), values: values)
+                                        .offset(y: -30)
                                 }
                             }
                             .position(x: 180, y: 205)
                             VStack(spacing: 0) {
                                 let values = viewModel.values(for: .eyeliner)
-                            if !values.isEmpty {
-                                    VStack(spacing: 2) {
-                                        Text(viewModel.title(for: .eyeliner))
-                                            .font(.caption)
-                                            .bold()
-                                            .foregroundColor(.black)
-                                            .offset(y: -30)
-                                        ForEach(values, id: \.self) { val in
-                                            Text(val)
-                                                .font(.caption)
-                                                .foregroundColor(.gray)
-                                                .padding(4)
-                                                .background(Color.white.opacity(0.6))
-                                                .cornerRadius(6)
-                                                .offset(y: -30)
-                                        }
-                                    }
+                                if !values.isEmpty {
+                                    CosmeticOverlayLabel(title: viewModel.title(for: .eyeliner), values: values)
+                                        .offset(y: -30)
                                 }
                             }
                             .position(x: 328, y: 170)


### PR DESCRIPTION
## 概要

`InputMakeupView` / `MakeupDetailView` / `CompareMakeupView` の3画面でコピペになっていた
「部位ラベル＋選択コスメのピル表示」ブロックを共通ビュー部品に切り出しました。

Closes #22

## 変更内容

- **新規** `ReMake/View/Components/CosmeticOverlayLabel.swift`
  - `CosmeticOverlayLabel` … 部位ラベル＋選択コスメ一覧をまとめた再利用ビュー（表示位置は呼び出し側が指定）
  - `View.cosmeticPillStyle()` … コスメ1件分のピル装飾を共通化した View 拡張
- 3画面の重複ブロック（計28箇所）を `CosmeticOverlayLabel(title:values:)` 呼び出しに置換
- 差し引き約314行削減（95行追加 / 409行削除）

## 補足

- `InputMakeupView` のみラベル–ピル間隔が `spacing: 0` でしたが、他2画面に合わせて `spacing: 2` に統一しています（見た目はほぼ同じ、ピル間隔が2pt広がる程度）。

## 確認

- `xcodebuild ... build` で **BUILD SUCCEEDED** を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)