### PR TITLE
メイク詳細画面に削除ボタンを追加 (feat #18)

### DIFF
--- a/ReMake/View/MakeupDetailView.swift
+++ b/ReMake/View/MakeupDetailView.swift
@@ -5,6 +5,9 @@ import SwiftData
 struct  MakeupDetailView: View {
     let record: MakeupRecord
     @StateObject private var viewModel: MakeupDetailViewModel
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+    @State private var showDeleteAlert = false
 
     init(record: MakeupRecord) {
         self.record = record
@@ -158,6 +161,24 @@ struct  MakeupDetailView: View {
                 Spacer()
                 Spacer()
                
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    showDeleteAlert = true
+                } label: {
+                    Image(systemName: "trash")
+                        .foregroundColor(.red)
+                }
+            }
+        }
+        .alert("このメイクを削除しますか？", isPresented: $showDeleteAlert) {
+            Button("キャンセル", role: .cancel) {}
+            Button("削除", role: .destructive) {
+                modelContext.delete(record)
+                try? modelContext.save()
+                dismiss()
             }
         }
     }


### PR DESCRIPTION
## 概要

保存済みメイクの詳細画面（`MakeupDetailView`）から、そのメイクを削除できるようにしました。

Closes #18

## 変更内容

- ナビゲーションバー右上にゴミ箱ボタン（`ToolbarItem(placement: .navigationBarTrailing)`）を追加
- タップで確認アラートを表示し、「削除」で `MakeupRecord` を `modelContext` から削除 → 保存 → `dismiss()` で一覧へ戻る
- 一覧画面（`SavedMakeListView`）は `@Query` の変化を `.onChange` で監視しているため、削除は自動で反映される

## 確認

- `xcodebuild ... build` で **BUILD SUCCEEDED** を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)