### PR TITLE
feat: 楽天コスメ検索APIをコスメ追加画面に統合

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# 楽天アプリIDなどの秘密情報を含むため、Git管理から除外する。
+# クローン時は APIConfig.example.swift をコピーして APIConfig.swift を作成し、
+# 自分の applicationId を設定すること。
+ReMake/Service/APIConfig.swift

--- a/ReMake/Model/CosmeticModel.swift
+++ b/ReMake/Model/CosmeticModel.swift
@@ -25,6 +25,8 @@ class Cosmetic {
     }
 
     var listProduct: String {
-        "\(brand) \(product) \(color)"
+        [brand, product, color]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
     }
 }

--- a/ReMake/Service/APIConfig.swift.example
+++ b/ReMake/Service/APIConfig.swift.example
@@ -1,0 +1,28 @@
+//
+//  APIConfig.swift.example
+//  ReMake
+//
+//  APIConfig.swift のテンプレート。
+//  APIConfig.swift は楽天アプリID・アクセスキーを含むため .gitignore で除外している。
+//  このファイルを APIConfig.swift にコピーし、各値を自分のもの
+//  （https://webservice.rakuten.co.jp/ で発行）に書き換えて使うこと。
+//  2026年2月の仕様変更で applicationId と accessKey の両方が必須。
+//
+
+import Foundation
+
+enum APIConfig {
+    /// 楽天ウェブサービスのアプリID（UUID形式・必須）
+    static let rakutenApplicationId = ""
+
+    /// 楽天ウェブサービスのアクセスキー（"pk_" で始まる文字列・必須）
+    static let rakutenAccessKey = ""
+
+    /// リクエストに付与する Origin（許可されたウェブサイトと一致させる）。
+    /// スキーム+ホストのみ（末尾スラッシュ・パスは付けない）。
+    static let rakutenOrigin = "https://github.com"
+
+    /// 化粧品ジャンルでの絞り込みに使うジャンルID（美容・コスメ・香水）
+    /// 0 にするとジャンル絞り込みなしで全商品から検索します。
+    static let rakutenCosmeticGenreId = 100939
+}

--- a/ReMake/Service/RakutenCosmeticAPI.swift
+++ b/ReMake/Service/RakutenCosmeticAPI.swift
@@ -1,0 +1,129 @@
+//
+//  RakutenCosmeticAPI.swift
+//  ReMake
+//
+//  楽天市場 商品検索API(Rakuten Ichiba Item Search API)で
+//  コスメを検索するネットワーク層。
+//
+
+import Foundation
+
+/// 検索画面が使う軽量モデル（楽天のレスポンスを必要な分だけ抽出したもの）
+struct CosmeticSearchResult: Identifiable {
+    let id = UUID()
+    let name: String
+    let imageURL: URL?
+    let price: Int
+}
+
+/// API呼び出しで起こりうるエラー
+enum RakutenCosmeticAPIError: LocalizedError {
+    case missingApplicationId
+    case missingAccessKey
+    case invalidURL
+    case requestFailed
+    case decodingFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .missingApplicationId:
+            return "楽天アプリIDが設定されていません（APIConfig.swift）。"
+        case .missingAccessKey:
+            return "楽天アクセスキーが設定されていません（APIConfig.swift）。"
+        case .invalidURL:
+            return "検索URLの組み立てに失敗しました。"
+        case .requestFailed:
+            return "通信に失敗しました。電波状況を確認してください。"
+        case .decodingFailed:
+            return "検索結果の読み込みに失敗しました。"
+        }
+    }
+}
+
+struct RakutenCosmeticAPI {
+    // 2026年2月の仕様変更後のエンドポイント（旧 app.rakuten.co.jp は非推奨）。
+    private let endpoint = "https://openapi.rakuten.co.jp/ichibams/api/IchibaItem/Search/20220601"
+
+    /// キーワードでコスメを検索する
+    func search(keyword: String) async throws -> [CosmeticSearchResult] {
+        guard !APIConfig.rakutenApplicationId.isEmpty else {
+            throw RakutenCosmeticAPIError.missingApplicationId
+        }
+        guard !APIConfig.rakutenAccessKey.isEmpty else {
+            throw RakutenCosmeticAPIError.missingAccessKey
+        }
+
+        var components = URLComponents(string: endpoint)
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "applicationId", value: APIConfig.rakutenApplicationId),
+            URLQueryItem(name: "accessKey", value: APIConfig.rakutenAccessKey),
+            URLQueryItem(name: "keyword", value: keyword),
+            URLQueryItem(name: "hits", value: "20"),
+            URLQueryItem(name: "imageFlag", value: "1"),
+            URLQueryItem(name: "format", value: "json")
+        ]
+        if APIConfig.rakutenCosmeticGenreId > 0 {
+            queryItems.append(
+                URLQueryItem(name: "genreId", value: String(APIConfig.rakutenCosmeticGenreId))
+            )
+        }
+        components?.queryItems = queryItems
+
+        guard let url = components?.url else {
+            throw RakutenCosmeticAPIError.invalidURL
+        }
+
+        // 2026年仕様では Origin ヘッダーが無いと 403 になる。
+        var request = URLRequest(url: url)
+        request.setValue(APIConfig.rakutenOrigin, forHTTPHeaderField: "Origin")
+
+        let data: Data
+        do {
+            (data, _) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw RakutenCosmeticAPIError.requestFailed
+        }
+
+        do {
+            let response = try JSONDecoder().decode(RakutenSearchResponse.self, from: data)
+            return response.items.map { wrapper in
+                let item = wrapper.item
+                return CosmeticSearchResult(
+                    name: item.itemName,
+                    imageURL: item.mediumImageUrls.first.flatMap { URL(string: $0.imageUrl) },
+                    price: item.itemPrice
+                )
+            }
+        } catch {
+            throw RakutenCosmeticAPIError.decodingFailed
+        }
+    }
+}
+
+// MARK: - 楽天レスポンスのDTO
+
+private struct RakutenSearchResponse: Decodable {
+    let items: [RakutenItemWrapper]
+
+    enum CodingKeys: String, CodingKey {
+        case items = "Items"
+    }
+}
+
+private struct RakutenItemWrapper: Decodable {
+    let item: RakutenItem
+
+    enum CodingKeys: String, CodingKey {
+        case item = "Item"
+    }
+}
+
+private struct RakutenItem: Decodable {
+    let itemName: String
+    let itemPrice: Int
+    let mediumImageUrls: [RakutenImage]
+}
+
+private struct RakutenImage: Decodable {
+    let imageUrl: String
+}

--- a/ReMake/View/InputCosmeView.swift
+++ b/ReMake/View/InputCosmeView.swift
@@ -84,10 +84,9 @@ struct InputCosmeView: View {
 
 struct Mysheet: View {
     @Environment(\.dismiss) var dismiss
+    @StateObject private var searchViewModel = SearchCosmeticViewModel()
     var sections: [InputCosmeViewModel.CollapsibleSection]
-    @State public var brand: String = ""
     @State public var product: String = ""
-    @State public var color: String = ""
     @State private var selectedCategory: String = "化粧下地"
     var onComplete: (String, String, String, String) -> Void
 
@@ -100,7 +99,7 @@ struct Mysheet: View {
                     }
                     Spacer()
                     Button("完了") {
-                        onComplete(selectedCategory, brand, product, color)
+                        onComplete(selectedCategory, "", product, "")
                         dismiss()
                     }
                 }
@@ -108,7 +107,7 @@ struct Mysheet: View {
                     .font(.headline)
             }
             .padding(.bottom)
-            Spacer()
+
             HStack {
                 Text("カテゴリ")
                     .bold()
@@ -122,29 +121,78 @@ struct Mysheet: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             HStack {
-                Text("ブランド")
-                    .bold()
-                    .frame(width: 80, alignment: .leading)
-                TextField("ブランド名を入力してください", text: $brand)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-            }
-            HStack {
                 Text("商品名")
                     .bold()
                     .frame(width: 80, alignment: .leading)
-                TextField("商品名を入力してください", text: $product)
+                TextField("検索結果を選ぶか入力してください", text: $product)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
             }
-            HStack {
-                Text("色番/色名")
-                    .bold()
-                    .frame(width: 80, alignment: .leading)
-                TextField("色番/色名を入力してください", text: $color)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-            }
-            Spacer()
+
+            searchSection
         }
         .padding()
+    }
+
+    /// 楽天APIでコスメを検索し、結果をタップすると商品名欄に反映するセクション。
+    private var searchSection: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.secondary)
+                TextField("コスメを検索（楽天）", text: $searchViewModel.keyword)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .submitLabel(.search)
+                    .onSubmit {
+                        Task { await searchViewModel.search() }
+                    }
+                if searchViewModel.isLoading {
+                    ProgressView()
+                }
+            }
+
+            if let message = searchViewModel.errorMessage {
+                Text(message)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(searchViewModel.results) { result in
+                        Button {
+                            product = result.name
+                        } label: {
+                            HStack(alignment: .top, spacing: 12) {
+                                AsyncImage(url: result.imageURL) { image in
+                                    image.resizable().scaledToFill()
+                                } placeholder: {
+                                    Color(white: 0.92)
+                                }
+                                .frame(width: 64, height: 64)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(result.name)
+                                        .font(.subheadline)
+                                        .foregroundColor(.primary)
+                                        .lineLimit(3)
+                                        .multilineTextAlignment(.leading)
+                                    Text("¥\(result.price)")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                Spacer()
+                            }
+                            .padding(.vertical, 8)
+                        }
+                        Divider()
+                    }
+                }
+            }
+            .frame(maxHeight: .infinity)
+        }
+        .frame(maxHeight: .infinity)
     }
 }
 

--- a/ReMake/ViewModel/SearchCosmeticViewModel.swift
+++ b/ReMake/ViewModel/SearchCosmeticViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  SearchCosmeticViewModel.swift
+//  ReMake
+//
+//  楽天市場 商品検索APIを使ってコスメを検索する画面用のViewModel。
+//  RakutenCosmeticAPI（Service層）を呼び出し、結果・読み込み状態・
+//  エラーメッセージを @Published で公開する。
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor
+final class SearchCosmeticViewModel: ObservableObject {
+    @Published var keyword: String = ""
+    @Published var results: [CosmeticSearchResult] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private let api = RakutenCosmeticAPI()
+
+    /// 現在のキーワードでコスメを検索する。
+    func search() async {
+        let trimmed = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        isLoading = true
+        errorMessage = nil
+        do {
+            results = try await api.search(keyword: trimmed)
+            if results.isEmpty {
+                errorMessage = "該当するコスメが見つかりませんでした。"
+            }
+        } catch {
+            results = []
+            errorMessage = (error as? LocalizedError)?.errorDescription
+                ?? "検索に失敗しました。"
+        }
+        isLoading = false
+    }
+}


### PR DESCRIPTION
## 概要
コスメ追加画面に楽天市場の商品検索を組み込み、検索結果から選んでコスメを登録できるようにしました（Issue #25）。

## 変更内容
### 検索API層（Service）
- `RakutenCosmeticAPI.swift` を追加。楽天市場 商品検索API（**2026年2月の新仕様**）に対応：
  - エンドポイント `openapi.rakuten.co.jp/ichibams/api/...`
  - `applicationId` + `accessKey` の両方を付与
  - `Origin` ヘッダーを付与（無いと403になる仕様）
- `SearchCosmeticViewModel.swift` を追加（検索・読み込み状態・エラー管理）

### UI（コスメ追加シート）
- 「ブランド」「色番/色名」の入力欄を削除し、その分**検索結果の表示領域を拡大**
- 構成を「カテゴリ → 商品名 → 検索結果」に整理。検索結果をタップすると商品名欄に反映
- サムネイル・商品名を大きく表示して見やすく

### その他
- 空のブランド/色番で `listProduct` に余分な空白が出ないよう修正
- 秘密情報を含む `APIConfig.swift` を `.gitignore` で除外し、テンプレート `APIConfig.swift.example` を追加

## 動作確認
- `xcodebuild ... build` → **BUILD SUCCEEDED**
- 楽天APIへ実リクエストを投げ、コスメ商品（名前・価格・画像）が返ることを確認

## 注意点
- 検索結果のタップでは**商品名のみ**自動入力されます（楽天はブランド/商品名/色番を分けて返さないため）
- `APIConfig.swift`（applicationId / accessKey）はコミットに含まれません。クローン時は `APIConfig.swift.example` をコピーして自分の値を設定してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)