### PR TITLE
feat: コスメ管理リストに楽天の商品画像を表示

### DIFF
--- a/ReMake/Model/CosmeticModel.swift
+++ b/ReMake/Model/CosmeticModel.swift
@@ -15,13 +15,16 @@ class Cosmetic {
     var product: String
     var color: String
     var category: String
+    /// 楽天APIの商品画像URL（検索結果から登録した場合に保持。手入力時は nil）
+    var imageURL: String?
 
-    init(brand: String, product: String, color: String, category: String) {
+    init(brand: String, product: String, color: String, category: String, imageURL: String? = nil) {
         self.id = UUID()
         self.brand = brand
         self.product = product
         self.color = color
         self.category = category
+        self.imageURL = imageURL
     }
 
     var listProduct: String {

--- a/ReMake/View/InputCosmeView.swift
+++ b/ReMake/View/InputCosmeView.swift
@@ -31,12 +31,13 @@ struct InputCosmeView: View {
                         .background(Circle().fill(Color(red: 0xA6/255.0, green: 0x80/255.0, blue: 0x76/255.0)))
                 }
                 .sheet(isPresented: $viewModel.showsheet){
-                    Mysheet(sections: viewModel.sections) { category, brand, product, color in
+                    Mysheet(sections: viewModel.sections) { category, brand, product, color, imageURL in
                         viewModel.addCosmetic(
                             brand: brand,
                             product: product,
                             color: color,
                             category: category,
+                            imageURL: imageURL,
                             to: modelContext,
                             existingCosmetics: cosmetics
                         )
@@ -53,9 +54,19 @@ struct InputCosmeView: View {
             List {
                 ForEach($viewModel.sections) { $section in
                     DisclosureGroup(isExpanded: $section.isExpanded) {
-                        ForEach(section.items, id: \.self) { item in
-                            Text(item)
-                                .foregroundColor(Color(white: 0.3))
+                        ForEach(section.items) { item in
+                            HStack(spacing: 12) {
+                                AsyncImage(url: item.imageURL) { image in
+                                    image.resizable().scaledToFill()
+                                } placeholder: {
+                                    Color(white: 0.92)
+                                }
+                                .frame(width: 44, height: 44)
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+
+                                Text(item.name)
+                                    .foregroundColor(Color(white: 0.3))
+                            }
                         }
                         //削除機能
                         .onDelete { indexSet in
@@ -87,8 +98,9 @@ struct Mysheet: View {
     @StateObject private var searchViewModel = SearchCosmeticViewModel()
     var sections: [InputCosmeViewModel.CollapsibleSection]
     @State public var product: String = ""
+    @State private var selectedImageURL: String?
     @State private var selectedCategory: String = "化粧下地"
-    var onComplete: (String, String, String, String) -> Void
+    var onComplete: (String, String, String, String, String?) -> Void
 
     var body: some View {
         VStack {
@@ -99,7 +111,7 @@ struct Mysheet: View {
                     }
                     Spacer()
                     Button("完了") {
-                        onComplete(selectedCategory, "", product, "")
+                        onComplete(selectedCategory, "", product, "", selectedImageURL)
                         dismiss()
                     }
                 }
@@ -162,6 +174,7 @@ struct Mysheet: View {
                     ForEach(searchViewModel.results) { result in
                         Button {
                             product = result.name
+                            selectedImageURL = result.imageURL?.absoluteString
                         } label: {
                             HStack(alignment: .top, spacing: 12) {
                                 AsyncImage(url: result.imageURL) { image in

--- a/ReMake/ViewModel/InputCosmeViewModel.swift
+++ b/ReMake/ViewModel/InputCosmeViewModel.swift
@@ -11,10 +11,17 @@ import SwiftData
 
 @MainActor
 final class InputCosmeViewModel: ObservableObject {
+    /// リスト1行分のコスメ表示データ（名前と楽天の画像URL）
+    struct CosmeticItem: Identifiable, Hashable {
+        let id: UUID
+        let name: String
+        let imageURL: URL?
+    }
+
     struct CollapsibleSection: Identifiable {
         let id = UUID()
         let title: String
-        var items: [String]
+        var items: [CosmeticItem]
         var isExpanded: Bool = true
     }
 
@@ -38,7 +45,13 @@ final class InputCosmeViewModel: ObservableObject {
             let title = sections[index].title
             sections[index].items = cosmetics
                 .filter { $0.category == title }
-                .map { $0.listProduct }
+                .map { cosmetic in
+                    CosmeticItem(
+                        id: cosmetic.id,
+                        name: cosmetic.listProduct,
+                        imageURL: cosmetic.imageURL.flatMap { URL(string: $0) }
+                    )
+                }
         }
     }
 
@@ -47,6 +60,7 @@ final class InputCosmeViewModel: ObservableObject {
         product: String,
         color: String,
         category: String,
+        imageURL: String?,
         to context: ModelContext,
         existingCosmetics: [Cosmetic]
     ) {
@@ -54,7 +68,8 @@ final class InputCosmeViewModel: ObservableObject {
             brand: brand,
             product: product,
             color: color,
-            category: category
+            category: category,
+            imageURL: imageURL
         )
         context.insert(cosmetic)
         try? context.save()
@@ -67,15 +82,11 @@ final class InputCosmeViewModel: ObservableObject {
         from context: ModelContext,
         cosmetics: [Cosmetic]
     ) {
-        for index in offsets {
-            let itemToDelete = section.items[index]
-            if let cosmeticToDelete = cosmetics.first(where: { $0.listProduct == itemToDelete }) {
-                context.delete(cosmeticToDelete)
-            }
+        let idsToDelete = Set(offsets.map { section.items[$0].id })
+        for cosmetic in cosmetics where idsToDelete.contains(cosmetic.id) {
+            context.delete(cosmetic)
         }
         try? context.save()
-        updateSections(from: cosmetics.filter { cosmetic in
-            !offsets.contains { section.items[$0] == cosmetic.listProduct }
-        })
+        updateSections(from: cosmetics.filter { !idsToDelete.contains($0.id) })
     }
 }


### PR DESCRIPTION
## 概要
コスメ管理画面のリスト各行の左側に、楽天APIから取得した商品画像を表示するようにしました（Issue #28）。

## 変更内容
### モデル（`CosmeticModel.swift`）
- `Cosmetic` に `imageURL: String?` を追加。検索結果から登録したコスメは画像URLを保持（手入力時は `nil`）
- SwiftDataのオプショナルプロパティ追加のため、既存データは自動マイグレーションでそのまま動作

### ViewModel（`InputCosmeViewModel.swift`）
- リスト行用に `CosmeticItem`（名前＋画像URL）を追加し、`items` を `[String]` → `[CosmeticItem]` に変更
- `addCosmetic` に `imageURL` を追加
- 削除処理を `listProduct` 文字列一致から **id一致** に変更（より正確に）

### View（`InputCosmeView.swift`）
- コスメ管理リストの各行の左側に `AsyncImage`（44×44・角丸）で商品画像を表示。画像が無い場合はグレーのプレースホルダ
- 追加シートで検索結果タップ時に画像URLを保持し、登録時に渡すように

## 動作確認
- `xcodebuild ... build` → **BUILD SUCCEEDED**

## 注意点
- 本変更以前に登録済みのコスメは画像URLを持たないため、プレースホルダ表示になります（新規登録分から画像が表示されます）

🤖 Generated with [Claude Code](https://claude.com/claude-code)