### PR TITLE
feat: メイク入力画面で選択コスメを楽天画像で表示

### DIFF
--- a/ReMake/View/Components/CosmeticOverlayLabel.swift
+++ b/ReMake/View/Components/CosmeticOverlayLabel.swift
@@ -23,9 +23,13 @@ extension View {
 
 /// 部位名のラベルと、その部位で選択されたコスメ一覧をまとめて表示する。
 /// 表示位置（`.position` / `.offset`）は呼び出し側で指定する。
+///
+/// `imageURLByName` に「コスメ名(listProduct) → 画像URL」を渡すと、
+/// その名前のコスメは楽天画像のサムネイルで表示する（画像が無い名前は従来どおりテキスト）。
 struct CosmeticOverlayLabel: View {
     let title: String
     let values: [String]
+    var imageURLByName: [String: URL] = [:]
 
     var body: some View {
         VStack(spacing: 2) {
@@ -34,8 +38,18 @@ struct CosmeticOverlayLabel: View {
                 .bold()
                 .foregroundColor(.black)
             ForEach(values, id: \.self) { value in
-                Text(value)
-                    .cosmeticPillStyle()
+                if let url = imageURLByName[value] {
+                    AsyncImage(url: url) { image in
+                        image.resizable().scaledToFill()
+                    } placeholder: {
+                        Color(white: 0.92)
+                    }
+                    .frame(width: 56, height: 56)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                } else {
+                    Text(value)
+                        .cosmeticPillStyle()
+                }
             }
         }
     }

--- a/ReMake/View/InputMakeupView.swift
+++ b/ReMake/View/InputMakeupView.swift
@@ -21,6 +21,19 @@ struct InputMakeupView: View {
     var pickerOptions: [String] {
         viewModel.pickerOptions(from: cosmetics)
     }
+
+    /// コスメ名(listProduct) → 楽天の画像URL の対応表。
+    /// 選択コスメのオーバーレイ表示で画像を出すために使う。
+    var imageURLByName: [String: URL] {
+        Dictionary(
+            cosmetics.compactMap { cosmetic -> (String, URL)? in
+                guard let urlString = cosmetic.imageURL,
+                      let url = URL(string: urlString) else { return nil }
+                return (cosmetic.listProduct, url)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
     
     var body: some View {
         ZStack{
@@ -66,7 +79,7 @@ struct InputMakeupView: View {
                             // Example for .lip
                             VStack(spacing: 0) {
                                 if let values = viewModel.selectedItemLists[.lip] {
-                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .lip), values: values)
+                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .lip), values: values, imageURLByName: imageURLByName)
                                         .offset(y: -20)
                                 }
                                 Button(action: {
@@ -82,7 +95,7 @@ struct InputMakeupView: View {
 
                             VStack(spacing: 0) {
                                 if let values = viewModel.selectedItemLists[.highlight] {
-                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .highlight), values: values)
+                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .highlight), values: values, imageURLByName: imageURLByName)
                                         .offset(y: -20)
                                 }
                                 Button(action: {
@@ -98,7 +111,7 @@ struct InputMakeupView: View {
 
                             VStack(spacing: 0) {
                                 if let values = viewModel.selectedItemLists[.eyebrow] {
-                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .eyebrow), values: values)
+                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .eyebrow), values: values, imageURLByName: imageURLByName)
                                         .offset(y: -20)
                                 }
                                 Button(action: {
@@ -158,7 +171,7 @@ struct InputMakeupView: View {
 
                             VStack(spacing: 0) {
                                 if let values = viewModel.selectedItemLists[.base] {
-                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .base), values: values)
+                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .base), values: values, imageURLByName: imageURLByName)
                                         .offset(y: -20)
                                 }
                                 Button(action: {
@@ -174,7 +187,7 @@ struct InputMakeupView: View {
 
                             VStack(spacing: 0) {
                                 if let values = viewModel.selectedItemLists[.cheek] {
-                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .cheek), values: values)
+                                    CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .cheek), values: values, imageURLByName: imageURLByName)
                                         .offset(y: -20)
                                 }
                                 Button(action: {
@@ -191,7 +204,7 @@ struct InputMakeupView: View {
                             ZStack {
                                 VStack(spacing: 0) {
                                     if let values = viewModel.selectedItemLists[.eyeshadow] {
-                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .eyeshadow), values: values)
+                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .eyeshadow), values: values, imageURLByName: imageURLByName)
                                             .offset(y: -30)
                                     }
                                     Button(action: {
@@ -251,7 +264,7 @@ struct InputMakeupView: View {
 
                                 VStack(spacing: 0) {
                                     if let values = viewModel.selectedItemLists[.mascara] {
-                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .mascara), values: values)
+                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .mascara), values: values, imageURLByName: imageURLByName)
                                             .offset(y: -30)
                                     }
                                     Button(action: {
@@ -267,7 +280,7 @@ struct InputMakeupView: View {
 
                                 VStack(spacing: 0) {
                                     if let values = viewModel.selectedItemLists[.colorlense] {
-                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .colorlense), values: values)
+                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .colorlense), values: values, imageURLByName: imageURLByName)
                                             .offset(y: -30)
                                     }
                                     Button(action: {
@@ -283,7 +296,7 @@ struct InputMakeupView: View {
 
                                 VStack(spacing: 0) {
                                     if let values = viewModel.selectedItemLists[.eyeliner] {
-                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .eyeliner), values: values)
+                                        CosmeticOverlayLabel(title: viewModel.sectionTitle(for: .eyeliner), values: values, imageURLByName: imageURLByName)
                                             .offset(y: -30)
                                     }
                                     Button(action: {


### PR DESCRIPTION
## 概要
メイク入力画面でコスメを選択した際、これまで名前テキストで表示していた箇所に、SwiftDataに保存済みの楽天商品画像を表示するようにしました（Issue #30）。

## 変更内容
### 共有コンポーネント（`CosmeticOverlayLabel.swift`）
- 引数 `imageURLByName: [String: URL]`（デフォルト空）を追加
- 値（コスメ名 = `listProduct`）に対応する画像URLがあれば `AsyncImage` でサムネイル（56×56・角丸）を表示、無ければ従来どおりテキスト表示
- デフォルト空引数のため、**詳細画面・比較画面の表示は変更なし**（後方互換）

### メイク入力画面（`InputMakeupView.swift`）
- `imageURLByName` 計算プロパティを追加（`@Query` のコスメから `listProduct → 画像URL` の対応表を生成）
- 9つの `CosmeticOverlayLabel` 呼び出しすべてにこの対応表を渡し、選択コスメが画像で表示されるように

## 動作確認
- `xcodebuild ... build` → **BUILD SUCCEEDED**

## 注意点
- 検索結果から登録したコスメ（画像URLあり）は画像で表示。手入力で登録したコスメ（画像URLなし）は従来どおり名前テキストで表示されます

🤖 Generated with [Claude Code](https://claude.com/claude-code)